### PR TITLE
Enforce a datetime import convention

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,9 @@ select = [
     "RUF",
 ]
 
+[tool.ruff.lint.flake8-import-conventions.extend-aliases]
+datetime = "dt"  # https://adamj.eu/tech/2019/09/12/how-i-import-pythons-datetime-module/
+
 [tool.ruff.lint.flake8-tidy-imports]
 ban-relative-imports = "all"
 


### PR DESCRIPTION
Enforce importing `datetime` as `dt` for consistency and clarity (https://adamj.eu/tech/2019/09/12/how-i-import-pythons-datetime-module/).