### PR TITLE
Remove tabbit.schemas from the contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,8 +70,6 @@ overview may be helpful.
   session management.
 - `tabbit.exceptions`: Tabbit exception types.
 - `tabbit.http`: manages the user-facing API.
-- `tabbit.schemas`: describes and manages the intermediary data between the API
-  and database.
 
 [uv]: https://docs.astral.sh/uv/
 [pre-commit]: https://pre-commit.com/


### PR DESCRIPTION
We no longer have a top-level schemas modules. Instead, we have seperate schemas based on purpose (e.g., for the database, API, and domain).